### PR TITLE
Fix: 공지 사항 목록 조회시에 display되지 않는 필드는 포함하지 않도록 수정

### DIFF
--- a/src/notice/serializers.py
+++ b/src/notice/serializers.py
@@ -3,7 +3,13 @@ from rest_framework import serializers
 from .models import Notice
 
 
+class NoticeSummarizeListSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Notice
+        fields = ["id", "title", "is_pinned"]
+
+
 class NoticeSerializer(serializers.ModelSerializer):
     class Meta:
         model = Notice
-        fields = ["title", "content", "is_deleted", "is_pinned", "created_at", "updated_at"]
+        fields = ["id", "title", "content", "is_pinned", "created_at", "updated_at"]

--- a/src/notice/views.py
+++ b/src/notice/views.py
@@ -4,15 +4,21 @@ from rest_framework.viewsets import GenericViewSet
 from core.responses.base import BaseResponse
 
 from .models import Notice
-from .serializers import NoticeSerializer
+from .serializers import NoticeSerializer, NoticeSummarizeListSerializer
 from .swagger import NoticeAPIDocs
 
 
 @extend_schema_view(list=NoticeAPIDocs.list(), retrieve=NoticeAPIDocs.retrieve())
 class NoticeViewSet(GenericViewSet):
-    serializer_class = NoticeSerializer
     queryset = Notice.objects.filter(is_deleted=False)
     filterset_fields = ("is_pinned",)
+
+    def get_serializer_class(self):
+        match self.action:
+            case "list":
+                return NoticeSummarizeListSerializer
+            case "retrieve":
+                return NoticeSerializer
 
     def list(self, request, *args, **kwargs) -> BaseResponse:
         queryset = self.get_queryset()


### PR DESCRIPTION
## 💡 Issue
- #

## 📌 Work Description
- NoticeSummarizeListSerializer 구현
- get_serializer_class에서 action에 따라 다른 serializer를 호출하도록 변경

## ✅ 테스트 항목
- [ ]

## 📝 Reference
-

## 📚 Etc
-
