### PR TITLE
Fix: 필터링이 적용되지 않던 문제 수정

### DIFF
--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -64,7 +64,7 @@ REST_FRAMEWORK = {
     "DEFAULT_SCHEMA_CLASS": "drf_spectacular.openapi.AutoSchema",
     "DEFAULT_PAGINATION_CLASS": "core.paginations.PageNumberPagination",
     "EXCEPTION_HANDLER": "core.middlewares.exception_handler.custom_exception_handler",
-    "Default_FILTER_BACKENDS": ["django_filters.rest_framework.DjangoFilterBackend"],
+    "DEFAULT_FILTER_BACKENDS": ["django_filters.rest_framework.DjangoFilterBackend"],
     "PAGE_SIZE_QUERY_PARAM": "page_size",
     "PAGE_SIZE": 10,
     "MAX_PAGE_SIZE": 100,

--- a/src/notice/views.py
+++ b/src/notice/views.py
@@ -21,7 +21,7 @@ class NoticeViewSet(GenericViewSet):
                 return NoticeSerializer
 
     def list(self, request, *args, **kwargs) -> BaseResponse:
-        queryset = self.get_queryset()
+        queryset = self.filter_queryset(self.get_queryset())
         page = self.paginate_queryset(queryset)
         serializer = self.get_serializer(page or queryset, many=True)
         return self.get_paginated_response(serializer.data)


### PR DESCRIPTION
## 💡 Issue
- #

## 📌 Work Description
- DRF 설정 파일 오타 수정
- 공지 사항 목록 조회 API에서 filter_queryset을 사용하도록 수정

## ✅ 테스트 항목
- [x] is_pinned=true API 요청 시 고정된 공지만 조회 되는지 확인
- [x] is_pinned=false API 요청 시 고정되지 않은 공지만 조회 되는지 확인
- [x] is_pinned 쿼리 없이 API 요청 시 전체 공지가 조회 되는지 확인  

## 📝 Reference
-

## 📚 Etc
-
