### PR TITLE
production 도커 이미지를 빌드 할 때 AWS 관련 환경 변수를 로드 할 수 없던 문제 수정

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -20,7 +20,8 @@ WORKDIR $WORKSPACE
 
 COPY --from=builder $WORKSPACE/.venv/lib/python3.12/site-packages/ /usr/local/lib/python3.12/site-packages/
 COPY --from=builder $WORKSPACE/src .
+COPY ./docker/entrypoint.sh $WORKSPACE/entrypoint.sh
 
 EXPOSE 8080
 
-CMD ["python", "manage.py", "runserver", "0.0.0.0:8080"]
+ENTRYPOINT [ "entrypoint.sh" ]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -9,7 +9,6 @@ COPY . .
 
 RUN pip3 install uv
 RUN uv sync
-RUN uv run python src/manage.py collectstatic --noinput
 
 
 FROM python:3.12-slim

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,0 +1,3 @@
+python3 manage.py migrate
+python3 manage.py collectstatic --noinput
+python3 manage.py runserver 0.0.0.0:8080


### PR DESCRIPTION
## 💡 Issue
- production 도커 이미지 빌드 시에 collectstatic을 실행
- collectstatic은 s3에 static 파일을 업로드 하기에 AWS 관련 환경 변수가 필요
- 최초 settings.py 호출 할 때 환경 변수가 존재하지 않아 빌드 실패

## 📌 Work Description
- production 이미지 빌드 시에 collectstatic을 수행하지 않도록 수정

## ✅ 테스트 항목

## 📝 Reference
-

## 📚 Etc
-
